### PR TITLE
Adds ArgoCD outputs to module

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,6 +20,7 @@ jobs:
         platform:
           - ocp4_latest
           - ocp46
+          - ocp45
       #      max-parallel: 1
       fail-fast: false
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 
 module "gitops" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.14.0"
+  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.15.1"
 
   cluster_type        = var.cluster_type
   ingress_subdomain   = var.ingress_subdomain

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,11 +7,13 @@ output "argocd_namespace" {
 output "argocd_host" {
   description = "The ingress host for the Argo CD instance"
   value = module.gitops.ingress_host
+  sensitive = true
 }
 
 output "argocd_url" {
   description = "The ingress url for the Argo CD instance"
   value = module.gitops.ingress_url
+  sensitive = true
 }
 
 output "argocd_username" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,3 +3,24 @@ output "argocd_namespace" {
   description = "The namespace where the ArgoCD instance has been provisioned"
   value       = module.gitops.namespace
 }
+
+output "argocd_host" {
+  description = "The ingress host for the Argo CD instance"
+  value = module.gitops.ingress_host
+}
+
+output "argocd_url" {
+  description = "The ingress url for the Argo CD instance"
+  value = module.gitops.ingress_url
+}
+
+output "argocd_username" {
+  description = "The username of the default ArgoCD admin user"
+  value = module.gitops.username
+}
+
+output "argocd_password" {
+  description = "The password of the default ArgoCD admin user"
+  value = module.gitops.password
+  sensitive = true
+}


### PR DESCRIPTION
- Bumps argocd module to v2.15.1 to get output variables
- Adds host, url, username, and password from argocd output to module output
- Adds ocp4.5 cluster to test matrix

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>