### PR TITLE
Removes ocp 4.5 from test matrix for now

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,7 +20,7 @@ jobs:
         platform:
           - ocp4_latest
           - ocp46
-          - ocp45
+#          - ocp45
       #      max-parallel: 1
       fail-fast: false
 


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>