### PR TITLE
Bumps argocd and tekton module versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "gitops" {
 }
 
 module "pipelines" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-tekton.git?ref=v2.3.0"
+  source = "github.com/cloud-native-toolkit/terraform-tools-tekton.git?ref=v2.3.1"
 
   cluster_config_file_path = var.cluster_config_file
   cluster_type             = var.cluster_type

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "gitops" {
 }
 
 module "pipelines" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-tekton.git?ref=v2.2.1"
+  source = "github.com/cloud-native-toolkit/terraform-tools-tekton.git?ref=v2.3.0"
 
   cluster_config_file_path = var.cluster_config_file
   cluster_type             = var.cluster_type

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 
 module "gitops" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.15.1"
+  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.16.0"
 
   cluster_type        = var.cluster_type
   ingress_subdomain   = var.ingress_subdomain


### PR DESCRIPTION
* Bumps tekton module to v2.3.1
* Bumps argocd module to v2.16.0

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>