### PR TITLE
Updates pipelines and sealed_secret submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ module "openshift_cicd" {
   olm_namespace       = module.dev_capture_olm_state.namespace
   operator_namespace  = module.dev_capture_operator_state.namespace
   app_namespace       = module.dev_capture_tools_state.namespace
+  sealed_secret_cert  = module.cert.cert
+  sealed_secret_private_key = module.cert.private_key
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "gitops" {
 }
 
 module "pipelines" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-tekton.git?ref=v2.3.2"
+  source = "github.com/cloud-native-toolkit/terraform-tools-tekton.git?ref=v2.3.4"
 
   cluster_config_file_path = var.cluster_config_file
   cluster_type             = var.cluster_type
@@ -21,12 +21,10 @@ module "pipelines" {
 }
 
 module "sealed_secrets" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-sealed-secrets.git?ref=v1.0.8"
+  source = "github.com/cloud-native-toolkit/terraform-tools-sealed-secrets.git?ref=v1.1.0"
 
   cluster_config_file = var.cluster_config_file
   private_key = var.sealed_secret_private_key
-  private_key_file = var.sealed_secret_private_key_file
-  public_key  = var.sealed_secret_public_key
-  public_key_file = var.sealed_secret_public_key_file
+  cert = var.sealed_secret_cert
   namespace = var.sealed_secret_namespace
 }

--- a/module.yaml
+++ b/module.yaml
@@ -29,6 +29,10 @@ versions:
       refs:
         - source: github.com/ibm-garage-cloud/terraform-k8s-namespace
           version: ">= 2.1.0"
+    - id: cert
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-util-sealed-secret-cert
+          version: ">= 0.0.0"
   variables:
     - name: cluster_type
       moduleRef:
@@ -60,11 +64,11 @@ versions:
         id: namespace
         output: name
         discriminator: sealed-secrets
-    - name: sealed_secret_public_key
-      scope: global
+    - name: sealed_secret_cert
+      moduleRef:
+        id: cert
+        output: cert
     - name: sealed_secret_private_key
-      scope: global
-    - name: sealed_secret_public_key_file
-      scope: global
-    - name: sealed_secret_private_key_file
-      scope: global
+      moduleRef:
+        id: cert
+        output: private_key

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,10 +32,6 @@ output "argocd_password" {
   sensitive = true
 }
 
-output "sealed_secrets_public_key" {
-  value = module.sealed_secrets.public_key
-}
-
 output "sealed_secrets_private_key" {
   value = module.sealed_secrets.private_key
   sensitive = true

--- a/test/stages/stage1-cert.tf
+++ b/test/stages/stage1-cert.tf
@@ -1,0 +1,4 @@
+module "cert" {
+  source = "github.com/cloud-native-toolkit/terraform-util-sealed-secret-cert.git"
+
+}

--- a/test/stages/stage2-openshift-cicd.tf
+++ b/test/stages/stage2-openshift-cicd.tf
@@ -7,4 +7,6 @@ module "openshift_cicd" {
   olm_namespace       = module.dev_capture_olm_state.namespace
   operator_namespace  = module.dev_capture_operator_state.namespace
   app_namespace       = module.dev_capture_tools_state.namespace
+  sealed_secret_cert  = module.cert.cert
+  sealed_secret_private_key = module.cert.private_key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,27 +29,15 @@ variable "ingress_subdomain" {
   default     = ""
 }
 
-variable "sealed_secret_public_key" {
+variable "sealed_secret_cert" {
   type        = string
-  description = "The public key that will be used to encrypt sealed secrets. If not provided, a new one will be generated"
+  description = "The certificate that will be used to encrypt sealed secrets. If not provided, a new one will be generated"
   default     = ""
 }
 
 variable "sealed_secret_private_key" {
   type        = string
   description = "The private key that will be used to decrypt sealed secrets. If not provided, a new one will be generated"
-  default     = ""
-}
-
-variable "sealed_secret_public_key_file" {
-  type        = string
-  description = "The file containing the public key that will be used to encrypt the sealed secrets. If not provided a new public key will be generated"
-  default     = ""
-}
-
-variable "sealed_secret_private_key_file" {
-  type        = string
-  description = "The file containin the private key that will be used to encrypt the sealed secrets. If not provided a new private key will be generated"
   default     = ""
 }
 


### PR DESCRIPTION
- Bumps pipelines to v2.3.3 to pick up wait for webhook fix
- Bumps sealed_secrets to v1.1.0 to update handling of certs
- Adds dependency to tools-sealed-secret-cert in metadata to offload cert generation

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>