### PR TITLE
Updates argocd to v2.17.10 and uses cluster interface in metadata

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 
 module "gitops" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.17.8"
+  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.17.10"
 
   cluster_config_file = var.cluster_config_file
   olm_namespace       = var.olm_namespace

--- a/module.yaml
+++ b/module.yaml
@@ -12,15 +12,8 @@ versions:
     - ocp4
   dependencies:
     - id: cluster
-      refs:
-        - source: github.com/ibm-garage-cloud/terraform-ibm-container-platform
-          version: ">= 1.7.0"
-        - source: github.com/ibm-garage-cloud/terraform-ibm-ocp-vpc
-          version: ">= 1.0.0"
-        - source: github.com/ibm-garage-cloud/terraform-k8s-ocp-cluster
-          version: ">= 2.0.0"
-        - source: github.com/ibm-garage-cloud/terraform-ocp-login
-          version: ">= 1.0.0"
+      interface: github.com/cloud-native-toolkit/automation-modules#cluster
+      refs: []
     - id: olm
       refs:
         - source: github.com/ibm-garage-cloud/terraform-k8s-olm


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>