### PR TITLE
Updates argocd module to v2.18.10

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
 
 
 module "gitops" {
-  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.18.9"
+  source = "github.com/cloud-native-toolkit/terraform-tools-argocd.git?ref=v2.18.10"
 
   cluster_config_file = var.cluster_config_file
   olm_namespace       = var.olm_namespace


### PR DESCRIPTION
- Picks up fix to only install openshift-gitops operator

closes #48

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>